### PR TITLE
Improvements to the login flow

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   import { Background } from "@components";
-  import { login } from "@authentication";
+  import { initializeGoogleLogin } from "@authentication";
   import { onMount } from "svelte";
 
   let src = "";
 
   onMount(async () => {
-    login();
+    initializeGoogleLogin();
   });
 </script>
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { Background } from "@components";
-  import { initializeGoogleLogin } from "@authentication";
+  import { initializeGoogleLogin } from "@auth";
   import { onMount } from "svelte";
 
   let src = "";

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   import { Background } from "@components";
-  import { getGoogleAuthToken } from "@auth";
+  import { login } from "@authentication";
   import { onMount } from "svelte";
 
   let src = "";
 
   onMount(async () => {
-    getGoogleAuthToken();
+    login();
   });
 </script>
 

--- a/src/components/Background/helpers.ts
+++ b/src/components/Background/helpers.ts
@@ -1,5 +1,4 @@
-import { storedAccessToken } from "@store";
-import { get } from "svelte/store";
+import { token } from "@authentication";
 
 type Data = {
   mediaItems: {
@@ -30,7 +29,7 @@ export const getSources = async () => {
     {
       method: "POST",
       headers: {
-        Authorization: `Bearer ${get(storedAccessToken)}`,
+        Authorization: `Bearer ${token()}`,
       },
       body: JSON.stringify({
         filters: {

--- a/src/components/Background/helpers.ts
+++ b/src/components/Background/helpers.ts
@@ -1,4 +1,4 @@
-import { token } from "@authentication";
+import { googleToken } from "@authentication";
 
 type Data = {
   mediaItems: {
@@ -29,7 +29,7 @@ export const getSources = async () => {
     {
       method: "POST",
       headers: {
-        Authorization: `Bearer ${token()}`,
+        Authorization: `Bearer ${googleToken()}`,
       },
       body: JSON.stringify({
         filters: {

--- a/src/components/Background/helpers.ts
+++ b/src/components/Background/helpers.ts
@@ -1,4 +1,4 @@
-import { googleToken } from "@authentication";
+import { googleToken } from "@auth";
 
 type Data = {
   mediaItems: {

--- a/src/components/Background/helpers.ts
+++ b/src/components/Background/helpers.ts
@@ -23,7 +23,7 @@ type Data = {
   }[];
 };
 
-export const getSources = async () => {
+export const getSources = async (): Promise<Array<string>> => {
   const response = await fetch(
     "https://photoslibrary.googleapis.com/v1/mediaItems:search",
     {

--- a/src/components/Background/helpers.ts
+++ b/src/components/Background/helpers.ts
@@ -1,4 +1,4 @@
-import { googleAuthToken } from "@store";
+import { storedAccessToken } from "@store";
 import { get } from "svelte/store";
 
 type Data = {
@@ -30,7 +30,7 @@ export const getSources = async () => {
     {
       method: "POST",
       headers: {
-        Authorization: `Bearer ${get(googleAuthToken)}`,
+        Authorization: `Bearer ${get(storedAccessToken)}`,
       },
       body: JSON.stringify({
         filters: {

--- a/src/util/auth/google.ts
+++ b/src/util/auth/google.ts
@@ -1,34 +1,97 @@
-import { googleAuthToken, googleAuthExpiration } from "@store";
+import { storedAccessToken, storedRefreshToken } from "@store";
 import { get } from "svelte/store";
 
-const storeAuth = () => {
-  const accesToken = window.location.hash.split("&")[0].split("=")[1];
-  googleAuthToken.set(accesToken);
-  const expiresIn = +window.location.hash.split("&")[2].split("=")[1];
-  googleAuthExpiration.set(new Date(new Date().getTime() + expiresIn * 1000));
-  window.location.replace(import.meta.env.VITE_HOSTURL);
+// Scopes must match the scopes configured in the Google Developers Console.
+const SCOPES = [
+  "https://www.googleapis.com/auth/photoslibrary.readonly",
+].join("_");
+
+
+interface AuthenticationResponse {
+  accessToken: string,
+  refreshToken: string
 };
 
-const redirToAuth = () => {
-  // Scopes must match the scopes configured in the Google Developers Console.
-  const scopes = [
-    "https://www.googleapis.com/auth/photoslibrary.readonly",
-  ].join("_");
-  const authorizationUrl =
-    "https://accounts.google.com/o/oauth2/v2/auth" +
-    `?scope=${scopes}` +
-    `&include_granted_scopes=true` +
-    `&response_type=token` +
-    `&redirect_uri=${import.meta.env.VITE_HOSTURL}` +
-    `&client_id=${import.meta.env.VITE_GOOGLE_CLIENT_ID}`;
-  window.location.assign(authorizationUrl);
+const save = (accessToken: string, refreshToken: string) => {
+  storedAccessToken.set(accessToken);
+  storedRefreshToken.set(refreshToken);
 };
+
+const authenticate = async (authorizationCode: string): AuthenticationResponse => {
+  const authenticationURL = new URL("https://oauth2.googleapis.com/token");
+  authenticationURL.searchParams.append("client_id", `${import.meta.env.VITE_GOOGLE_CLIENT_ID}`);
+  authenticationURL.searchParams.append("client_secret", `${import.meta.env.VITE_GOOGLE_CLIENT_SECRET}`);
+  authenticationURL.searchParams.append("code", `${authorizationCode}`);
+  authenticationURL.searchParams.append("grant_type", "authorization_code");
+  authenticationURL.searchParams.append("redirect_uri", `${import.meta.env.VITE_HOSTURL}`);
+
+  const response = await fetch(authenticationURL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded"
+    }
+  });
+
+  const body = await response.json();
+
+  return {
+    accessToken: body.access_token,
+    refreshToken: body.refresh_token
+  };
+};
+
+const authorizate = () => {
+  const authorizationURL = new URL("https://accounts.google.com/o/oauth2/v2/auth");
+  authorizationURL.searchParams.append("client_id", `${import.meta.env.VITE_GOOGLE_CLIENT_ID}`);
+  authorizationURL.searchParams.append("redirect_uri", `${import.meta.env.VITE_HOSTURL}`);
+  authorizationURL.searchParams.append("response_type", "code");
+  authorizationURL.searchParams.append("scope", `${SCOPES}`);
+  authorizationURL.searchParams.append("access_type", "offline");
+  authorizationURL.searchParams.append("prompt", "consent");
+  authorizationURL.searchParams.append("include_granted_scopes", "true");
+
+  window.location.assign(authorizationURL);
+};
+
+const processAuthorizationCode = (params: string): (string|null) => {
+  const code = new URLSearchParams(params).get("code")
+
+  if (code) {
+    return encodeURI(code)
+  }
+
+  return null;
+};
+
+const hasAuthorizationError = (params: string): boolean => {
+  return new URLSearchParams(params).get("error") !== null
+}
+
+const hasAuthorizationSuccess = (params: string): boolean => {
+  return processAuthorizationCode(params) !== null
+}
 
 export const getGoogleAuthToken = () => {
-  //If we just came back from a redirect, store the result
-  if (window.location.hash) {
-    storeAuth();
-  } else if (!get(googleAuthToken) || get(googleAuthExpiration) < new Date()) {
-    redirToAuth();
+  if (hasAuthorizationError(window.location.search)) {
+    console.log("User refused to authorizate :(");
+    return
   }
+
+  if (!get(storedAccessToken) && !hasAuthorizationSuccess(window.location.search)) {
+    authorizate();
+    return
+  }
+
+  const authorizationCode = processAuthorizationCode(window.location.search)
+
+  authenticate(authorizationCode)
+    .then((tokens) => {
+      save(tokens.accessToken, tokens.refreshToken);
+      // Redirect for now breaks the exchange between the authorization code and access token.
+      // If you want to test it just navigate back to the root yourself
+      // window.location.replace(import.meta.env.VITE_HOSTURL);
+    })
+    .catch((exception) => {
+      console.log(`Failed to exchange authorization for authentication token ${exception}`);
+    });
 };

--- a/src/util/auth/google_authentication_repository.ts
+++ b/src/util/auth/google_authentication_repository.ts
@@ -1,8 +1,8 @@
-import { secureStore } from "@storage";
+import { createSecureStore } from "@storage";
 import { get } from "svelte/store";
 
-const storedAccessToken = secureStore<string>("access_token", null);
-const storedRefreshToken = secureStore<string>("refresh_token", null);
+const storedAccessToken = createSecureStore<string>("access_token", null);
+const storedRefreshToken = createSecureStore<string>("refresh_token", null);
 
 // Scopes must match the scopes configured in the Google Developers Console.
 const SCOPES = [
@@ -43,7 +43,7 @@ const authenticate = async (authorizationCode: string): Promise<AuthenticationRe
   };
 };
 
-const authorizate = () => {
+const requestAuthorizationCode = () => {
   const authorizationURL = new URL("https://accounts.google.com/o/oauth2/v2/auth");
   authorizationURL.searchParams.append("client_id", `${import.meta.env.VITE_GOOGLE_CLIENT_ID}`);
   authorizationURL.searchParams.append("redirect_uri", `${import.meta.env.VITE_HOSTURL}`);
@@ -72,13 +72,13 @@ const hasAuthorizationSuccess = (params: string): boolean => processAuthorizatio
 
 export const login = () => {
   if (hasAuthorizationError(window.location.search)) {
-    console.log("User refused to authorizate :(");
+    console.log("User refused to authenticate :(");
     return;
   }
 
   if (!isLoggedIn() && !hasAuthorizationSuccess(window.location.search)) {
-    console.log("Asking for user to authorization our app...");
-    authorizate();
+    console.log("Asking for user authenticate to our app...");
+    requestAuthorizationCode();
     return;
   }
 

--- a/src/util/auth/google_authentication_repository.ts
+++ b/src/util/auth/google_authentication_repository.ts
@@ -66,13 +66,9 @@ const processAuthorizationCode = (params: string): (string|null) => {
   return null;
 };
 
-const hasAuthorizationError = (params: string): boolean => {
-  return new URLSearchParams(params).get("error") !== null;
-}
+const hasAuthorizationError = (params: string): boolean => new URLSearchParams(params).get("error") !== null;
 
-const hasAuthorizationSuccess = (params: string): boolean => {
-  return processAuthorizationCode(params) !== null;
-}
+const hasAuthorizationSuccess = (params: string): boolean => processAuthorizationCode(params) !== null;
 
 export const login = () => {
   if (hasAuthorizationError(window.location.search)) {

--- a/src/util/auth/google_authentication_repository.ts
+++ b/src/util/auth/google_authentication_repository.ts
@@ -14,7 +14,7 @@ interface AuthenticationResponse {
   refreshToken: string
 };
 
-const save = (accessToken: string, refreshToken: string) => {
+const save = (accessToken: string, refreshToken: string): void => {
   console.log(`Saving access token & refresh token...`);
   storedAccessToken.set(accessToken);
   storedRefreshToken.set(refreshToken);
@@ -43,7 +43,7 @@ const authenticate = async (authorizationCode: string): Promise<AuthenticationRe
   };
 };
 
-const requestAuthorizationCode = () => {
+const requestAuthorizationCode = (): void => {
   const authorizationURL = new URL("https://accounts.google.com/o/oauth2/v2/auth");
   authorizationURL.searchParams.append("client_id", `${import.meta.env.VITE_GOOGLE_CLIENT_ID}`);
   authorizationURL.searchParams.append("redirect_uri", `${import.meta.env.VITE_HOSTURL}`);
@@ -70,7 +70,7 @@ const hasAuthorizationError = (params: string): boolean => new URLSearchParams(p
 
 const hasAuthorizationSuccess = (params: string): boolean => processAuthorizationCode(params) !== null;
 
-export const login = () => {
+export const login = (): void => {
   if (hasAuthorizationError(window.location.search)) {
     console.log("User refused to authenticate :(");
     return;
@@ -99,4 +99,4 @@ export const login = () => {
 
 export const isLoggedIn = (): boolean => get(storedAccessToken) !== null;
 
-export const token = () => get(storedAccessToken);
+export const token = (): string => get(storedAccessToken);

--- a/src/util/auth/google_authentication_repository.ts
+++ b/src/util/auth/google_authentication_repository.ts
@@ -15,12 +15,12 @@ interface AuthenticationResponse {
 };
 
 const save = (accessToken: string, refreshToken: string) => {
-  console.log(`Saving access_token:(${accessToken}), refresh_token:(${refreshToken})`);
+  console.log(`Saving access token & refresh token...`);
   storedAccessToken.set(accessToken);
   storedRefreshToken.set(refreshToken);
 };
 
-const authenticate = async (authorizationCode: string): AuthenticationResponse => {
+const authenticate = async (authorizationCode: string): Promise<AuthenticationResponse> => {
   const authenticationURL = new URL("https://oauth2.googleapis.com/token");
   authenticationURL.searchParams.append("client_id", `${import.meta.env.VITE_GOOGLE_CLIENT_ID}`);
   authenticationURL.searchParams.append("client_secret", `${import.meta.env.VITE_GOOGLE_CLIENT_SECRET}`);

--- a/src/util/auth/index.ts
+++ b/src/util/auth/index.ts
@@ -1,1 +1,1 @@
-export { getGoogleAuthToken } from "./google";
+export { login, isLoggedIn, token } from "./google_authentication_repository";

--- a/src/util/auth/index.ts
+++ b/src/util/auth/index.ts
@@ -1,1 +1,5 @@
-export { login, isLoggedIn, token } from "./google_authentication_repository";
+import { login, isLoggedIn, token } from "./google_authentication_repository";
+
+export const initializeGoogleLogin = () => login()
+export const isLoggedIntoGoogleAccount = () => isLoggedIn()
+export const googleToken = () => token()

--- a/src/util/storage/index.ts
+++ b/src/util/storage/index.ts
@@ -1,0 +1,1 @@
+export { genericStore, secureStore } from "./store";

--- a/src/util/storage/index.ts
+++ b/src/util/storage/index.ts
@@ -1,1 +1,1 @@
-export { genericStore, secureStore } from "./store";
+export { createGenericStore, createSecureStore } from "./store";

--- a/src/util/storage/store.ts
+++ b/src/util/storage/store.ts
@@ -1,6 +1,6 @@
 import { writable } from "svelte/store";
 
-function createStore<T>(key: string, initialValue?: T | null) {
+export function genericStore<T>(key: string, initialValue?: T | null) {
   // Get the value from localStorage if it exists
   const cachedValue = localStorage.getItem(key);
   const initial = cachedValue ? JSON.parse(cachedValue) : initialValue;
@@ -21,6 +21,7 @@ function createStore<T>(key: string, initialValue?: T | null) {
   };
 }
 
-// This should be stored in a secure storage
-export const storedAccessToken = createStore<string>("access_token", null);
-export const storedRefreshToken = createStore<string>("refresh_token", null);
+// TODO: This should be stored in a secure storage
+export function secureStore<T>(key: string, initialValue?: T | null) {
+  return genericStore(key, initialValue);
+}

--- a/src/util/storage/store.ts
+++ b/src/util/storage/store.ts
@@ -1,6 +1,6 @@
-import { writable } from "svelte/store";
+import { writable, type Writable } from "svelte/store";
 
-export function createGenericStore<T>(key: string, initialValue?: T | null) {
+export function createGenericStore<T>(key: string, initialValue?: T | null): Writable<T> {
   // Get the value from localStorage if it exists
   const cachedValue = localStorage.getItem(key);
   const initial = cachedValue ? JSON.parse(cachedValue) : initialValue;
@@ -22,6 +22,6 @@ export function createGenericStore<T>(key: string, initialValue?: T | null) {
 }
 
 // TODO: This should be stored in a secure storage
-export function createSecureStore<T>(key: string, initialValue?: T | null) {
+export function createSecureStore<T>(key: string, initialValue?: T | null): Writable<T> {
   return createGenericStore(key, initialValue);
 }

--- a/src/util/storage/store.ts
+++ b/src/util/storage/store.ts
@@ -1,6 +1,6 @@
 import { writable } from "svelte/store";
 
-export function genericStore<T>(key: string, initialValue?: T | null) {
+export function createGenericStore<T>(key: string, initialValue?: T | null) {
   // Get the value from localStorage if it exists
   const cachedValue = localStorage.getItem(key);
   const initial = cachedValue ? JSON.parse(cachedValue) : initialValue;
@@ -22,6 +22,6 @@ export function genericStore<T>(key: string, initialValue?: T | null) {
 }
 
 // TODO: This should be stored in a secure storage
-export function secureStore<T>(key: string, initialValue?: T | null) {
-  return genericStore(key, initialValue);
+export function createSecureStore<T>(key: string, initialValue?: T | null) {
+  return createGenericStore(key, initialValue);
 }

--- a/src/util/store.ts
+++ b/src/util/store.ts
@@ -21,8 +21,6 @@ function createStore<T>(key: string, initialValue?: T | null) {
   };
 }
 
-export const googleAuthToken = createStore<string>("googleAuthToken", null);
-export const googleAuthExpiration = createStore<Date>(
-  "googleAuthExpiration",
-  null
-);
+// This should be stored in a secure storage
+export const storedAccessToken = createStore<string>("access_token", null);
+export const storedRefreshToken = createStore<string>("refresh_token", null);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "paths": {
       "@components": ["./src/components/"],
       "@icons": ["./src/icons/"],
-      "@authentication": ["./src/util/auth/"],
+      "@auth": ["./src/util/auth/"],
       "@storage": ["./src/util/storage/"]
     }
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,8 +11,8 @@
     "paths": {
       "@components": ["./src/components/"],
       "@icons": ["./src/icons/"],
-      "@auth": ["./src/util/auth/"],
-      "@store": ["./src/util/store"]
+      "@authentication": ["./src/util/auth/"],
+      "@storage": ["./src/util/storage/"]
     }
   },
   "include": ["src/**/*.d.ts", "src/**/*.ts", "src/**/*.js", "src/**/*.svelte"],


### PR DESCRIPTION
Previously we were using the authorization token we got from Google's auth endpoint and use that in all the follow up calls as if it was a access_token(it was).

The downside of this approach was that we wouldn't get a refresh token, so after 1h we would need to re-authenticate again.

This PR changes that, in a when calling the Google's auth endpoint we request a `code` instead of a `token`, and with the given code we call Google's token endpoint to exchange that code for an `access_token` & `refresh_token`